### PR TITLE
fixed builder

### DIFF
--- a/src/browser/schema.json
+++ b/src/browser/schema.json
@@ -343,6 +343,14 @@
       "description": "Define the crossorigin attribute setting of elements that provide CORS support.",
       "default": "none",
       "enum": ["none", "anonymous", "use-credentials"]
+    },
+    "allowedCommonJsDependencies": {
+      "description": "A list of CommonJS packages that are allowed to be used without a build time warning.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Seems that angular 12 (re)introduced the usage of allowedCommonJsDependencies. Without this change the browser serve will not run due to invalid configuration.